### PR TITLE
move test_string to parse in test_lang

### DIFF
--- a/casper/testing_language.py
+++ b/casper/testing_language.py
@@ -16,12 +16,9 @@ class TestLangCBC:
 
     TOKEN_PATTERN = '([A-Za-z]*)([0-9]*)([-]*)([A-Za-z0-9]*)'
 
-    def __init__(self, test_string, val_weights, display=False):
-        if test_string == '':
-            raise Exception("Please pass in a valid test string")
+    def __init__(self, val_weights, display=False):
 
         self.validator_set = ValidatorSet(val_weights)
-        self.test_string = test_string
         self.display = display
         self.network = Network(self.validator_set)
 
@@ -56,9 +53,9 @@ class TestLangCBC:
         if block_name in self.blocks:
             raise ValueError('Block {} already exists'.format(block_name))
 
-    def parse(self):
+    def parse(self, test_string):
         """Parse the test_string, and run the test"""
-        for token in self.test_string.split(' '):
+        for token in test_string.split(' '):
             letter, validator, dash, name = re.match(self.TOKEN_PATTERN, token).groups()
             if letter+validator+dash+name != token:
                 raise ValueError("Bad token: %s" % token)

--- a/conftest.py
+++ b/conftest.py
@@ -12,11 +12,11 @@ def pytest_addoption(parser):
 
 
 def run_test_lang_with_reports(test_string, weights):
-    TestLangCBC(test_string, weights, True).parse()
+    TestLangCBC(weights, True).parse(test_string)
 
 
 def run_test_lang_without_reports(test_string, weights):
-    TestLangCBC(test_string, weights, False).parse()
+    TestLangCBC(weights, False).parse(test_string)
 
 
 @pytest.fixture

--- a/tests/casper/test_block.py
+++ b/tests/casper/test_block.py
@@ -20,8 +20,8 @@ def test_equality_of_copies_off_genesis(validator):
 
 def test_equality_of_copies_of_non_genesis(report):
     test_string = "B0-A S1-A B1-B S0-B B0-C S1-C B1-D S0-D H0-D"
-    test_lang = TestLangCBC(test_string, {0: 10, 1: 11}, report)
-    test_lang.parse()
+    test_lang = TestLangCBC({0: 10, 1: 11}, report)
+    test_lang.parse(test_string)
 
     for block in test_lang.blocks:
         shallow_copy = copy.copy(block)
@@ -44,8 +44,8 @@ def test_non_equality_of_copies_off_genesis():
 
 def test_unique_block_creation_in_test_lang(report):
     test_string = "B0-A S1-A B1-B S0-B B0-C S1-C B1-D S0-D H0-D"
-    test_lang = TestLangCBC(test_string, {0: 10, 1: 11}, report)
-    test_lang.parse()
+    test_lang = TestLangCBC({0: 10, 1: 11}, report)
+    test_lang.parse(test_string)
 
     num_equal = 0
     for block in test_lang.blocks:
@@ -72,8 +72,8 @@ def test_is_in_blockchain__separate_genesis():
 
 def test_is_in_blockchain__test_lang(report):
     test_string = "B0-A S1-A B1-B S0-B B0-C S1-C B1-D S0-D H0-D"
-    test_lang = TestLangCBC(test_string, {0: 11, 1: 10}, report)
-    test_lang.parse()
+    test_lang = TestLangCBC({0: 11, 1: 10}, report)
+    test_lang.parse(test_string)
 
     prev = test_lang.blocks['A']
     for b in ['B', 'C', 'D']:

--- a/tests/casper/test_forkchoice.py
+++ b/tests/casper/test_forkchoice.py
@@ -77,8 +77,8 @@ def test_reverse_message_arrival_order_forkchoice_four_val(test_lang_runner):
     test_lang_runner(test_string, {0: 5, 1: 6, 2: 7, 3: 8.1})
 
 
+@pytest.mark.skip(reason="test not yet implemented")
 def test_different_message_arrival_order_forkchoice_many_val():
-    # TODO
     pass
 
 


### PR DESCRIPTION
Addresses issue #72 

- Remove `test_string` from `TestLangCBC.__init__`
- Add `test_string` to `TestLangCBC.parse`
- Update tests to conform to new API
- Add tests for testing sequential calls to `parse`