### PR TITLE
[WIP] Feat/network rework

### DIFF
--- a/casper/blockchain/blockchain_plot_tool.py
+++ b/casper/blockchain/blockchain_plot_tool.py
@@ -19,16 +19,14 @@ class BlockchainPlotTool(PlotTool):
         self.block_fault_tolerance = {}
         self.message_labels = {}
 
-    def update(self, message_paths=None, sent_messages=None, new_messages=None):
+    def update(self, actions_taken=None, new_messages=None):
         """Updates displayable items with new messages and paths"""
-        if message_paths is None:
-            message_paths = []
-        if sent_messages is None:
-            sent_messages = dict()
+        if actions_taken is None:
+            actions_taken = []
         if new_messages is None:
             new_messages = dict()
 
-        self._update_communications(message_paths, sent_messages, new_messages)
+        self._update_communications(actions_taken, new_messages)
         self._update_blockchain(new_messages)
         self._update_block_fault_tolerance()
         self._update_message_labels(new_messages)
@@ -68,9 +66,9 @@ class BlockchainPlotTool(PlotTool):
 
         return vals_chain_edges
 
-    def _update_communications(self, message_paths, sent_messages, new_messages):
-        for sender, receiver in message_paths:
-            self.communications.append([sent_messages[sender], new_messages[receiver]])
+    def _update_communications(self, actions_taken, new_messages):
+        for message, receiver in actions_taken:
+            self.communications.append([message, new_messages[receiver]])
 
     def _update_blockchain(self, new_messages):
         for message in new_messages.values():

--- a/casper/blockchain/blockchain_view.py
+++ b/casper/blockchain/blockchain_view.py
@@ -83,6 +83,7 @@ class BlockchainView(AbstractView):
 
     def update_safe_estimates(self, validator_set):
         """Checks safety on messages in views forkchoice, and updates last_finalized_block"""
+        return
         tip = self.estimate()
 
         prev_last_finalized_block = self.last_finalized_block

--- a/casper/network.py
+++ b/casper/network.py
@@ -10,41 +10,47 @@ class Network:
         self.validator_set = validator_set
         self.global_view = protocol.View(set())
         self.message_queue = Q.PriorityQueue()
-        self.current_time = 0
+        self.current_step = 0
+        self.delay = self.zero
+
+    def zero(self, sender, reciever):
+        """Sample delay function"""
+        return 0
 
 
-    def send(self, new_message, validator):
+    def send_to_all_validators(self, message):
+        """Adds a message to the message queue for all other validators"""
+        for receiver in self.validator_set:
+            if message.sender == receiver:
+                continue
+            self.send(message, receiver)
+
+
+    def send(self, message, validator):
         """Adds a message the queue to send to a validator"""
-        self.global_view.add_messages(set([new_message]))
-        message_tuple = (self.current_time + r.randint(0, 1) + r.random(), new_message, validator)
-        print(message_tuple)
+        self.global_view.add_messages(set([message]))
 
+        delivery_step = self.current_step + self.delay(message.sender, validator) + r.random()
+        message_tuple = (delivery_step, message, validator)
         self.message_queue.put(message_tuple)
 
-
-    def step_forward(self, time_delta):
-        self.current_time += time_delta
+    def step_forward(self, num_steps):
+        self.current_step += num_steps
         return self.do_current_actions()
 
     def do_current_actions(self):
         actions_taken = []
 
-        if self.message_queue.empty():
-            return actions_taken
+        while not self.message_queue.empty():
+            time, message, reciever = self.message_queue.get()
+            if time > self.current_step:
+                return actions_taken
 
-        time, message, reciever = self.message_queue.get()
-        while time < self.current_time:
             assert reciever in self.validator_set, "...expected reciever to be a known validator"
             assert message.header in self.global_view.justified_messages, ("...only propagate "
                                                                            "from global view")
             reciever.receive_messages({message})
-
             actions_taken.append((message, reciever))
-
-            if self.message_queue.empty():
-                return actions_taken
-
-            time, message, reciever = self.message_queue.get()
 
         return actions_taken
 

--- a/casper/network.py
+++ b/casper/network.py
@@ -1,4 +1,6 @@
 """The network module .... """
+import random as r
+import queue as Q
 from casper.blockchain.blockchain_protocol import BlockchainProtocol
 
 
@@ -7,15 +9,44 @@ class Network:
     def __init__(self, validator_set, protocol=BlockchainProtocol):
         self.validator_set = validator_set
         self.global_view = protocol.View(set())
+        self.message_queue = Q.PriorityQueue()
+        self.current_time = 0
 
-    def propagate_message_to_validator(self, message, validator):
-        """Propagate a message to a validator."""
-        print(message)
-        assert message.header in self.global_view.justified_messages, ("...expected only to propagate messages "
-                                                      "from the global view")
-        assert validator in self.validator_set, "...expected a known validator"
 
-        validator.receive_messages(set([message]))
+    def send(self, new_message, validator):
+        """Adds a message the queue to send to a validator"""
+        self.global_view.add_messages(set([new_message]))
+        message_tuple = (self.current_time + r.randint(0, 1) + r.random(), new_message, validator)
+        print(message_tuple)
+
+        self.message_queue.put(message_tuple)
+
+
+    def step_forward(self, time_delta):
+        self.current_time += time_delta
+        return self.do_current_actions()
+
+    def do_current_actions(self):
+        actions_taken = []
+
+        if self.message_queue.empty():
+            return actions_taken
+
+        time, message, reciever = self.message_queue.get()
+        while time < self.current_time:
+            assert reciever in self.validator_set, "...expected reciever to be a known validator"
+            assert message.header in self.global_view.justified_messages, ("...only propagate "
+                                                                           "from global view")
+            reciever.receive_messages({message})
+
+            actions_taken.append((message, reciever))
+
+            if self.message_queue.empty():
+                return actions_taken
+
+            time, message, reciever = self.message_queue.get()
+
+        return actions_taken
 
     def get_message_from_validator(self, validator):
         """Get a message from a validator."""

--- a/simulations/utils.py
+++ b/simulations/utils.py
@@ -26,8 +26,7 @@ def message_maker(mode):
         def random(validator_set, num_messages=1):
             """Each round, some randomly selected validators propagate their most recent
             message to other randomly selected validators, who then create new messages."""
-            pairs = list(itertools.permutations(validator_set, 2))
-            return r.sample(pairs, num_messages)
+            return r.sample(validator_set.validators, num_messages)
 
         return random
 

--- a/simulations/utils.py
+++ b/simulations/utils.py
@@ -40,10 +40,10 @@ def message_maker(mode):
             round_robin.next_sender_index = (sender_index + 1) % len(validator_set)
             receiver_index = round_robin.next_sender_index
 
-            return [[
+            return [
                 sorted_validators[sender_index],
                 sorted_validators[receiver_index]
-            ]]
+            ]
 
         round_robin.next_sender_index = 0
         return round_robin


### PR DESCRIPTION
This is a huge work in progress. Lots of redesign needs to happen before this is ready to merge.

As of now, the network is maintaining a priority queue of messages. The priority of these messages is determined by some function that should be specified to the network. (Note that it is possible to have the priority of these messages change as things progress if that is wanted.) They are also prioritized by the "step" on which they will be delivered. A message with a lower step number will be delivered to its respective recipient before a message with a higher step number. 

Furthermore, this function that determines the step that the messages are delivered on can be specified pairwise between any two validators. This is likely the most general model of connectivity that we will need (and one can imagine this being used to simulate peering, etc).

Here are some examples of network models we could simulate:
- A synchronous model where every message is delivered by some bound specified to the network. (note, to some degree this means steps are essentially time. I'm not totally comfortable with this yet, but we will see).
- A partially synchronous model, where there every message is delivered by some bound that is unknown to the network. 
- A totally asynchronous network, where every message is delivered by some time infinitely in the future (maybe specified by some probability distribution).
- Other interesting schemes, such as those described here: https://github.com/ethereum/cbc-casper/issues/104

However, to this work, it seems we need to specify liveness strategies for the validators. As of now, the naive way of making blocks is kinda absurd (and we never actually build a blockchain). I'm not totally sure what the best way to do this is, though...