### PR TITLE
Feat/val abstraction

### DIFF
--- a/casper/abstract_view.py
+++ b/casper/abstract_view.py
@@ -1,5 +1,6 @@
 """The view module ... """
 
+
 class AbstractView(object):
     """A set of seen messages. For performance, also stores a dict of most recent messages."""
     def __init__(self, messages=None):
@@ -75,7 +76,6 @@ class AbstractView(object):
                 newly_justified_messages.update(self.get_new_justified_messages(new_message))
 
         return newly_justified_messages
-
 
     def _add_to_latest_messages(self, message):
         """Updates a views most recent messages, if this message is later"""

--- a/casper/abstract_view.py
+++ b/casper/abstract_view.py
@@ -41,9 +41,9 @@ class AbstractView(object):
 
     def receive_justified_message(self, message):
         """Upon receiving a justified message, resolves waiting messages and adds to view"""
-        new_justified_messages = self.get_new_justified_messages(message)
+        newly_justified_messages = self.get_newly_justified_messages(message)
 
-        for justified_message in new_justified_messages:
+        for justified_message in newly_justified_messages:
             self._add_to_latest_messages(justified_message)
             self._add_justified_remove_pending(justified_message)
             self.update_protocol_specific_view(justified_message)
@@ -60,12 +60,13 @@ class AbstractView(object):
             self.dependents_of_message[missing_message_hash].append(message.hash)
 
     def update_protocol_specific_view(self, message):
-        """ Can be implemented by child, though not necessarily
+        """ Can be implemented by child, though not necessary
         Updates a view's specific info, given a justified message"""
         pass
 
-    def get_new_justified_messages(self, message):
-        """Given a new message, resolve all messages that are waiting for it to be justified"""
+    def get_newly_justified_messages(self, message):
+        """Given a new justified message, get all messages that are now justified
+        due to its receipt"""
         newly_justified_messages = set([message])
 
         for dependent_hash in self.dependents_of_message.get(message.hash, set()):
@@ -73,7 +74,7 @@ class AbstractView(object):
 
             if self.num_missing_dependencies[dependent_hash] == 0:
                 new_message = self.pending_messages[dependent_hash]
-                newly_justified_messages.update(self.get_new_justified_messages(new_message))
+                newly_justified_messages.update(self.get_newly_justified_messages(new_message))
 
         return newly_justified_messages
 

--- a/casper/abstract_view.py
+++ b/casper/abstract_view.py
@@ -67,10 +67,7 @@ class AbstractView(object):
         """Given a new message, resolve all messages that are waiting for it to be justified"""
         newly_justified_messages = set([message])
 
-        if message.hash not in self.dependents_of_message:
-            return newly_justified_messages
-
-        for dependent_hash in self.dependents_of_message[message.hash]:
+        for dependent_hash in self.dependents_of_message.get(message.hash, set()):
             # sanity check!
             assert message.hash in self.missing_message_dependencies[dependent_hash]
 
@@ -78,10 +75,8 @@ class AbstractView(object):
 
             if not any(self.missing_message_dependencies[dependent_hash]):
                 new_message = self.pending_messages[dependent_hash]
-
                 newly_justified_messages.update(self.get_new_justified_messages(new_message))
 
-        del self.dependents_of_message[message.hash]
         return newly_justified_messages
 
 
@@ -96,6 +91,8 @@ class AbstractView(object):
         self.justified_messages[message.hash] = message
         if message.hash in self.missing_message_dependencies:
             del self.missing_message_dependencies[message.hash]
+        if message.hash in self.dependents_of_message:
+            del self.dependents_of_message[message.hash]
         if message.hash in self.pending_messages:
             del self.pending_messages[message.hash]
 

--- a/casper/abstract_view.py
+++ b/casper/abstract_view.py
@@ -46,7 +46,7 @@ class AbstractView(object):
         for justified_message in newly_justified_messages:
             self._add_to_latest_messages(justified_message)
             self._add_justified_remove_pending(justified_message)
-            self.update_protocol_specific_view(justified_message)
+            self._update_protocol_specific_view(justified_message)
 
     def receive_pending_message(self, message, missing_message_hashes):
         """Updates and stores pending messages and dependencies"""
@@ -58,11 +58,6 @@ class AbstractView(object):
                 self.dependents_of_message[missing_message_hash] = []
 
             self.dependents_of_message[missing_message_hash].append(message.hash)
-
-    def update_protocol_specific_view(self, message):
-        """ Can be implemented by child, though not necessary
-        Updates a view's specific info, given a justified message"""
-        pass
 
     def get_newly_justified_messages(self, message):
         """Given a new justified message, get all messages that are now justified
@@ -78,6 +73,11 @@ class AbstractView(object):
 
         return newly_justified_messages
 
+    def _update_protocol_specific_view(self, message):
+        """ Can be implemented by child, though not necessary
+        Updates a view's specific info, given a justified message"""
+        pass
+
     def _add_to_latest_messages(self, message):
         """Updates a views most recent messages, if this message is later"""
         if message.sender not in self.latest_messages:
@@ -86,6 +86,9 @@ class AbstractView(object):
             self.latest_messages[message.sender] = message
 
     def _add_justified_remove_pending(self, message):
+        """Atomic action that:
+        - removes all data related to tracking the not yet justified message
+        - adds message to justified dict"""
         self.justified_messages[message.hash] = message
         if message.hash in self.num_missing_dependencies:
             del self.num_missing_dependencies[message.hash]

--- a/casper/binary/binary_view.py
+++ b/casper/binary/binary_view.py
@@ -1,7 +1,6 @@
 """The blockchain view module extends a view for blockchain data structures """
 from casper.safety_oracles.clique_oracle import CliqueOracle
 from casper.abstract_view import AbstractView
-from casper.binary.bet import Bet
 import casper.binary.binary_estimator as estimator
 
 
@@ -10,7 +9,6 @@ class BinaryView(AbstractView):
     def __init__(self, messages=None):
         super().__init__(messages)
 
-        self.Message = Bet
         self.last_finalized_estimate = None
         self.first = True
 
@@ -22,7 +20,6 @@ class BinaryView(AbstractView):
 
     def update_safe_estimates(self, validator_set):
         """Checks safety on most recent created by this view"""
-        # check estimate safety on the most
         for bet in self.latest_messages.values():
             oracle = CliqueOracle(bet, self, validator_set)
             fault_tolerance, _ = oracle.check_estimate_safety()

--- a/casper/blockchain/blockchain_view.py
+++ b/casper/blockchain/blockchain_view.py
@@ -1,7 +1,6 @@
 """The blockchain view module extends a view for blockchain data structures """
 from casper.safety_oracles.clique_oracle import CliqueOracle
 from casper.abstract_view import AbstractView
-from casper.blockchain.block import Block
 import casper.blockchain.forkchoice as forkchoice
 
 
@@ -10,7 +9,6 @@ class BlockchainView(AbstractView):
     def __init__(self, messages=None):
         super().__init__(messages)
 
-        self.Message = Block
         self.children = dict()
         self.last_finalized_block = None
 
@@ -48,15 +46,17 @@ class BlockchainView(AbstractView):
             self.children[message.estimate] = set()
         self.children[message.estimate].add(message)
 
-        # update when_added cache
-        if message not in self.when_added:
-            self.when_added[message] = len(self.justified_messages)
+        self._update_when_added_cache(message)
 
     def _initialize_message_caches(self):
         self.when_added = {}
         for message in self.justified_messages.values():
             self.when_added[message] = 0
         self.when_finalized = {}
+
+    def _update_when_added_cache(self, message):
+        if message not in self.when_added:
+            self.when_added[message] = len(self.justified_messages)
 
     def _update_when_finalized_cache(self, tip):
         while tip and tip not in self.when_finalized:

--- a/casper/blockchain/blockchain_view.py
+++ b/casper/blockchain/blockchain_view.py
@@ -39,22 +39,9 @@ class BlockchainView(AbstractView):
 
             tip = tip.estimate
 
-    def make_new_message(self, validator):
-        justification = self.justification()
-        estimate = self.estimate()
-        sequence_number = self._next_sequence_number(validator)
-        display_height = self._next_display_height()
-
-        new_message = Block(estimate, justification, validator, sequence_number, display_height)
-        self.add_messages(set([new_message]))
-        assert new_message.hash in self.justified_messages  # sanity check
-
-        return new_message
-
-    def mark_message_as_fully_received(self, message):
-        """Given a now justified message, updates latest messages and children"""
-        assert message.hash not in self.justified_messages, "...should not have seen message!"
-        super().mark_message_as_fully_received(message)
+    def update_protocol_specific_view(self, message):
+        """Given a now justified message, updates children and when_recieved"""
+        assert message.hash in self.justified_messages, "...should not have seen message!"
 
         # update the children dictonary with the new message
         if message.estimate not in self.children:

--- a/casper/blockchain/blockchain_view.py
+++ b/casper/blockchain/blockchain_view.py
@@ -37,7 +37,7 @@ class BlockchainView(AbstractView):
 
             tip = tip.estimate
 
-    def update_protocol_specific_view(self, message):
+    def _update_protocol_specific_view(self, message):
         """Given a now justified message, updates children and when_recieved"""
         assert message.hash in self.justified_messages, "...should not have seen message!"
 

--- a/casper/validator.py
+++ b/casper/validator.py
@@ -2,6 +2,7 @@
 import numbers
 from casper.blockchain.blockchain_protocol import BlockchainProtocol
 
+
 class Validator(object):
     """A validator has a view from which it generates new messages and detects finalized blocks."""
     def __init__(self, name, weight, protocol=BlockchainProtocol, validator_set=None):
@@ -42,8 +43,8 @@ class Validator(object):
         It updates the validator's latest message, estimate, view, and latest observed messages."""
         estimate = self.estimate()
         justification = self.justification()
-        sequence_number = self.next_sequence_number()
-        display_height = self.next_display_height()
+        sequence_number = self._next_sequence_number()
+        display_height = self._next_display_height()
 
         new_message = self.protocol.Message(
             estimate,
@@ -57,7 +58,14 @@ class Validator(object):
 
         return new_message
 
-    def next_sequence_number(self):
+    def justification(self):
+        """Returns the headers of latest message seen from other validators."""
+        latest_message_headers = dict()
+        for validator in self.view.latest_messages:
+            latest_message_headers[validator] = self.view.latest_messages[validator].hash
+        return latest_message_headers
+
+    def _next_sequence_number(self):
         """Returns the sequence number for the next message from a validator"""
         last_message = self.my_latest_message()
 
@@ -65,7 +73,7 @@ class Validator(object):
             return last_message.sequence_number + 1
         return 0
 
-    def next_display_height(self):
+    def _next_display_height(self):
         """Returns the display height for a message created in this view"""
         if not any(self.view.latest_messages):
             return 0
@@ -75,10 +83,3 @@ class Validator(object):
             for validator in self.view.latest_messages
         )
         return max_height + 1
-
-    def justification(self):
-        """Returns the headers of latest message seen from other validators."""
-        latest_message_headers = dict()
-        for validator in self.view.latest_messages:
-            latest_message_headers[validator] = self.view.latest_messages[validator].hash
-        return latest_message_headers

--- a/casper/validator.py
+++ b/casper/validator.py
@@ -16,6 +16,7 @@ class Validator(object):
         self.weight = weight
         self.view = protocol.View(set())
         self.validator_set = validator_set
+        self.protocol = protocol
 
     def receive_messages(self, messages):
         """Allows the validator to receive protocol messages."""
@@ -30,7 +31,7 @@ class Validator(object):
         """This function returns the validator's latest message."""
         if self in self.view.latest_messages:
             return self.view.latest_messages[self]
-        raise KeyError("Validator has not previously created a message")
+        return None
 
     def update_safe_estimates(self):
         """The validator checks estimate safety on some estimate with some safety oracle."""
@@ -39,4 +40,45 @@ class Validator(object):
     def make_new_message(self):
         """This function produces a new latest message for the validator.
         It updates the validator's latest message, estimate, view, and latest observed messages."""
-        return self.view.make_new_message(self)
+        estimate = self.estimate()
+        justification = self.justification()
+        sequence_number = self.next_sequence_number()
+        display_height = self.next_display_height()
+
+        new_message = self.protocol.Message(
+            estimate,
+            justification,
+            self,
+            sequence_number,
+            display_height
+        )
+        self.view.add_messages(set([new_message]))
+        assert new_message.hash in self.view.justified_messages  # sanity check
+
+        return new_message
+
+    def next_sequence_number(self):
+        """Returns the sequence number for the next message from a validator"""
+        last_message = self.my_latest_message()
+
+        if last_message:
+            return last_message.sequence_number + 1
+        return 0
+
+    def next_display_height(self):
+        """Returns the display height for a message created in this view"""
+        if not any(self.view.latest_messages):
+            return 0
+
+        max_height = max(
+            self.view.latest_messages[validator].display_height
+            for validator in self.view.latest_messages
+        )
+        return max_height + 1
+
+    def justification(self):
+        """Returns the headers of latest message seen from other validators."""
+        latest_message_headers = dict()
+        for validator in self.view.latest_messages:
+            latest_message_headers[validator] = self.view.latest_messages[validator].hash
+        return latest_message_headers

--- a/casper/validator.py
+++ b/casper/validator.py
@@ -41,17 +41,12 @@ class Validator(object):
     def make_new_message(self):
         """This function produces a new latest message for the validator.
         It updates the validator's latest message, estimate, view, and latest observed messages."""
-        estimate = self.estimate()
-        justification = self.justification()
-        sequence_number = self._next_sequence_number()
-        display_height = self._next_display_height()
-
         new_message = self.protocol.Message(
-            estimate,
-            justification,
+            self.estimate(),
+            self.justification(),
             self,
-            sequence_number,
-            display_height
+            self._next_sequence_number(),
+            self._next_display_height()
         )
         self.view.add_messages(set([new_message]))
         assert new_message.hash in self.view.justified_messages  # sanity check

--- a/simulations/testing_language.py
+++ b/simulations/testing_language.py
@@ -110,7 +110,7 @@ class TestLangCBC(object):
             self.network.propagate_message_to_validator(block, validator)
 
         assert block.hash not in validator.view.pending_messages
-        assert block.hash not in validator.view.missing_message_dependencies
+        assert block.hash not in validator.view.num_missing_dependencies
         assert self.blocks[block_name].hash in validator.view.justified_messages
 
     def send_only_block(self, validator, block_name):

--- a/tests/casper/test_view.py
+++ b/tests/casper/test_view.py
@@ -12,8 +12,7 @@ def test_new_view():
     view = AbstractView()
 
     assert not any(view.justified_messages)
-    assert not view.latest_messages
-    assert not any(view.justification())
+    assert not any(view.latest_messages)
 
 
 def test_justification_stores_hash():
@@ -23,7 +22,7 @@ def test_justification_stores_hash():
     validator_0 = test_lang.validator_set.get_validator_by_name(0)
     validator_1 = test_lang.validator_set.get_validator_by_name(1)
 
-    justification = validator_1.view.justification()
+    justification = validator_1.justification()
 
     assert len(justification) == 2
     assert not isinstance(justification[validator_0], Block)
@@ -39,7 +38,7 @@ def test_justification_includes_justified_messages():
     validator_0 = test_lang.validator_set.get_validator_by_name(0)
     validator_1 = test_lang.validator_set.get_validator_by_name(1)
 
-    justification = validator_1.view.justification()
+    justification = validator_1.justification()
 
     assert len(justification) == 1
     assert validator_0 not in justification
@@ -47,7 +46,7 @@ def test_justification_includes_justified_messages():
 
     test_lang.parse('S1-B')
 
-    justification = validator_1.view.justification()
+    justification = validator_1.justification()
 
     assert len(justification) == 2
     assert justification[validator_0] == test_lang.blocks['B'].hash


### PR DESCRIPTION
This commit moves message generation out of the view and to the validator. This has two benefits of a) making a view much easier to understand, and b) making a validator more than just a wrapper for a view (in the past, we could have pretty much removed a validator class).

There is also some gentle cleanup of the receive messages function in the abstract_view class. I think it's much more readable than it was before: the recursive function has less side effects, function names are slightly improved, etc. 

This PR should be merged into cleanup whenever - and then from there into hash_linking.