### PR TITLE
(WIP) feat/heuristic-clique-oracle

### DIFF
--- a/casper/protocols/blockchain/blockchain_view.py
+++ b/casper/protocols/blockchain/blockchain_view.py
@@ -26,11 +26,10 @@ class BlockchainView(AbstractView):
     def update_safe_estimates(self, validator_set):
         """Checks safety on messages in views forkchoice, and updates last_finalized_block"""
         tip = self.estimate()
-
         while tip and tip != self.last_finalized_block:
             oracle = CliqueOracle(tip, self, validator_set)
+            heuristic_tolerance = oracle.check_heuristic_min_bound()
             fault_tolerance, _ = oracle.check_estimate_safety()
-
             if fault_tolerance > 0:
                 self.last_finalized_block = tip
                 self._update_when_finalized_cache(tip)


### PR DESCRIPTION
## Heuristic Clique Oracle ##

Right now, the functionality is appended to the CliqueOracle class. For testing, the oracle is being called from the blockchain view. 

To run: `python casper.py rand --validators 10 --rounds 100` Check console output to see it in action.

This oracle does a greedy search in attempt to find a large clique quickly. It iterates through the graph favoring vertices with the largest degree until it can reduce a clique.

The current implementation does not take into account weight, which I plan on adding in.

The greedy algorithm can also be extended beyond a simple lookup to do a full search on the graph space.

For more details see #134