### PR TITLE
Make math.round in gaussian delay no longer shadowed

### DIFF
--- a/simulations/network_delay.py
+++ b/simulations/network_delay.py
@@ -5,30 +5,30 @@ CONSTANT = 5
 MU = 10
 SIGMA = 5
 
-def no_delay(sender, reciever, round):
+def no_delay(sender, reciever, curr_round):
     """Messages deliver instantly"""
     return 0
 
 
-def constant_delay(sender, reciever, round):
+def constant_delay(sender, reciever, curr_round):
     """Messages take a constant number of rounds to deliver"""
     return CONSTANT
 
 
-def step_delay(sender, reciever, round):
+def step_delay(sender, reciever, curr_round):
     """Messages take 1 round to deliver"""
     return 1
 
 
-def random_delay(sender, reciever, round):
+def random_delay(sender, reciever, curr_round):
     """Messages take a random amount of time to deliver"""
     return random.randint(0, CONSTANT)
 
 
-def gaussian_delay(sender, reciever, round):
+def gaussian_delay(sender, reciever, curr_round):
     """Messages take a random amount of time to deliver
     (from a gaussian distribution)"""
-    return round(random.gauss(MU, SIGMA))
+    return round(random.gauss(MU, SIGMA).real)
 
 SELECT_NETWORK_DELAY = {
     'no-delay': no_delay,


### PR DESCRIPTION
Fixes

```
  File "/cbc-casper/simulations/network_delay.py", line 31, in gaussian_delay
    return round(random.gauss(MU, SIGMA))
TypeError: 'int' object is not callable
```